### PR TITLE
allow any version on peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "esm": "^3.2.25"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^3.10.1",
-    "@typescript-eslint/parser": "^3.10.1",
-    "eslint": "7.7.0",
-    "typescript": "^3.7.2"
+    "@typescript-eslint/eslint-plugin": "*",
+    "@typescript-eslint/parser": "*",
+    "eslint": "*",
+    "typescript": "*"
   }
 }


### PR DESCRIPTION
- move cdk terraform styling to sub-folder
- package bump
- upgrade eslint peer
- fix member-delimiter-style in terraform
- bump version
- add eslint prettier for terraform cdk
- bump package version
- fix prettierrc
- bump package version
- remove indentation errors in eslint on terraform
- bump package version
- allow any version on peer dependencies
